### PR TITLE
Speed up django migrate step

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,20 @@ The ``extra_env`` variable is a dict of keys and values that is
 desired to be injected into the environment as variables, via the
 ``envfile.j2`` template.
 
+Optimizations
+-------------
+
+If your staging and deployment environments do not use `requiretty` in
+`/etc/sudoers` you can turn on [SSH pipelining](http://docs.ansible.com/ansible/latest/intro_configuration.html#pipelining)
+for all ansible commands. If this is the case, add the following to your project
+`ansible.cfg` file:
+
+    [ssh_connection]
+    pipelining = True
+
+Notes
+-----
+
 See `geerlingguy/nodejs
 <https://github.com/geerlingguy/ansible-role-nodejs>`_ for the
 expected Ansible configuration variables for that role.

--- a/README.rst
+++ b/README.rst
@@ -119,13 +119,15 @@ desired to be injected into the environment as variables, via the
 Optimizations
 -------------
 
-If your staging and deployment environments do not use `requiretty` in
-`/etc/sudoers` you can turn on [SSH pipelining](http://docs.ansible.com/ansible/latest/intro_configuration.html#pipelining)
-for all ansible commands. If this is the case, add the following to your project
-`ansible.cfg` file:
+You can turn on [SSH pipelining](http://docs.ansible.com/ansible/latest/intro_configuration.html#pipelining)
+to speed up ansible commands (by minimizing SSH operations). Add the following
+to your project's `ansible.cfg` file:
 
     [ssh_connection]
     pipelining = True
+
+**Warning** this will cause deployments to break if `securetty` is used in your server's
+`/etc/sudoers` file.
 
 Notes
 -----

--- a/tasks/web.yml
+++ b/tasks/web.yml
@@ -24,7 +24,7 @@
 
 - name: migrate
   django_manage:
-    command: migrate
+    command="migrate --noinput -v 0"
     app_path: "{{ source_dir }}"
     virtualenv: "{{ venv_dir }}"
   become_user: "{{ project_user }}"

--- a/tasks/web.yml
+++ b/tasks/web.yml
@@ -24,7 +24,7 @@
 
 - name: migrate
   django_manage:
-    command="migrate --noinput -v 0"
+    command: migrate --noinput -v 0
     app_path: "{{ source_dir }}"
     virtualenv: "{{ venv_dir }}"
   become_user: "{{ project_user }}"


### PR DESCRIPTION
This reduces CPU of Django 1.8 significantly, while still applying
missing migrations.

For the craftcarejoy repository deploys go from around 9 minutes down to
4.5 minutes.

Refs https://tracker.specialtyfood.com/issues/5917