### PR TITLE
Fixes #10 - Exclude .env and node_modules when rsyncing for source_is_local

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@ Tequila-django
 
 Changes
 
+Unreleased
+-----------------------
+
+* Ignore .env and node_modules when rsync-ing source tree for
+  source_is_local processing.
+
+
 v 0.9.2 on Aug 17, 2017
 -----------------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -102,7 +102,9 @@
     rsync_path: "sudo rsync"  # Use sudo on the remote system
     recursive: true
     rsync_opts:
+      - "--exclude=.env"
       - "--exclude=.git"
+      - "--exclude=node_modules"
       - "--exclude=*.pyc"
   become: no  # stops synchronize trying to sudo locally
   when: source_is_local


### PR DESCRIPTION
This doesn't address any other aspects of #10 (out of time/inclination).