### PR TITLE
Change the check for devDependencies into a hard fail

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,13 +3,19 @@ Tequila-django
 
 Changes
 
-v 0.9.9 on Dec 11, 2017
+v 0.9.9 on Dec 12, 2017
 -----------------------
-* Issue a warning if npm packages are listed in devDependencies.
+
+* Throw a failure if the presence of packages in the project
+  package.json ``devDependencies`` object is detected.  Projects will
+  need to move their dependencies into the ``dependencies`` object
+  instead, or disable the check by setting ``ignore_devdependencies``
+  to ``true``.
 
 
 v 0.9.8 on Nov 27, 2017
 -----------------------
+
 * Properly quoting all environment variables.
 
 

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,7 @@ The following variables are used by the ``tequila-django`` role:
 - ``source_is_local`` **default:** ``false``
 - ``github_deploy_key`` **required if source_is_local is false**
 - ``local_project_dir`` **required if source_is_local**
+- ``ignore_devdependencies`` **default:** ``false``
 - ``extra_env`` **default:** empty dict
 
 The ``extra_env`` variable is a dict of keys and values that is
@@ -137,6 +138,15 @@ every web instance, since they'll be getting in each other's way.
 This variable set to ``true`` causes the ``collectstatic`` task to be
 run only once.
 
+Due to `some <https://github.com/npm/npm/issues/17471>`_ `issues
+<https://github.com/ansible/ansible/issues/29234>`_ discovered with
+npm not managing package installation when new packages are added to
+the ``devDependencies`` object in package.json, tequila-django checks
+for the presence of any packages in this variable and will throw an
+error if found.  This behavior can be disabled by setting
+``ignore_devdependencies`` to ``true``.
+
+
 Optimizations
 -------------
 
@@ -150,6 +160,7 @@ to your project's `ansible.cfg` file ::
 
 **Warning:** this will cause deployments to break if ``securetty`` is used in your server's
 ``/etc/sudoers`` file.
+
 
 Notes
 -----

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,4 +19,5 @@ use_newrelic: false
 source_is_local: false
 is_web: false
 is_worker: false
+ignore_devdependencies: false
 extra_env: {}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -137,15 +137,14 @@
   when: package_json.stat.exists == True
 
 - name: check developer dependencies
-  command: npm ls -dev --depth=0 --prefix {{ source_dir }}
+  command: npm ls -dev --parseable --prefix {{ source_dir }}
   register: dev_dependencies
-  failed_when: False
   when: package_json.stat.exists == True
 
-- name: devDependencies Warning
-  debug:
-    msg: "There are packages listed under devDependencies. Please move any packages you wish to use in production to dependencies."
-  when: dev_dependencies.stdout_lines[1] != '└── (empty)'
+- name: fail when there are project-level devDependencies
+  fail:
+    msg: "There are packages listed under `devDependencies`. Please move them to `dependencies` instead."
+  when: not ignore_devdependencies and package_json.stat.exists == True and dev_dependencies.stdout_lines|length > 1
 
 - name: clear out leftover build cruft from the project requirements
   file: path={{ venv_dir }}/build state=absent


### PR DESCRIPTION
The warning message is too hard to notice unless you were really
looking for it, and devDependencies is more for npm packages for
distribution, not full projects themselves.