### PR TITLE
TEQ-57: Adding additional env settings to envfile.j2 for Celery 4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,9 +16,12 @@ v 0.9.10+n on Month Day, Year
   Settings can be upgraded automatically using the Celery 4
   command line interface.
 
-  For more details, see the Celery 4 "What’s new in Celery
-  4.0" changelog document, in particular the "For Django
-  users and others who want to keep uppercase names" section.
+  For more details, see the Celery 4 `"What’s new in Celery
+  4.0" <http://docs.celeryproject.org/en/latest/whatsnew-4.0.html>`_
+  changelog document, in particular the "`For Django
+  users and others who want to keep uppercase names"
+  <http://docs.celeryproject.org/en/latest/whatsnew-4.0.html#lowercase-setting-names>`_
+  section.
 
 v 0.9.10 on Mar 2, 2018
 -----------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ v 0.9.10+n on Month Day, Year
 
   NOTE: if you are upgrading from Celery 3 to Celery 4, be
   aware of the changes made to Celery's setting names.
+  Most relevant to tequila-django, the changed names
+  include the environment-variable-dependent
+  settings determined by the secrets ``broker_host``
+  and ``broker_password``.
+
   Old setting names will still work after the change, but
   users are encouraged to upgrade as soon as possible.
   Settings can be upgraded automatically using the Celery 4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,23 @@ Tequila-django
 
 Changes
 
+v 0.9.10+n on Month Day, Year
+--------------------------
+
+* Add additional env vars to account for Celery 4's renamed
+  configuration settings.
+
+  NOTE: if you are upgrading from Celery 3 to Celery 4, be
+  aware of the changes made to Celery's setting names.
+  Old setting names will still work after the change, but
+  users are encouraged to upgrade as soon as possible.
+  Settings can be upgraded automatically using the Celery 4
+  command line interface.
+
+  For more details, see the Celery 4 "What’s new in Celery
+  4.0" changelog document, in particular the "For Django
+  users and others who want to keep uppercase names" section.
+
 v 0.9.10 on Mar 2, 2018
 -----------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Tequila-django
 
 Changes
 
-v 0.9.10+n on Month Day, Year
+v 0.9.11 on March 19, 2018
 --------------------------
 
 * Add additional env vars to account for Celery 4's renamed

--- a/README.rst
+++ b/README.rst
@@ -42,9 +42,9 @@ allow the roles to be installed into ``/etc/ansible/roles``) ::
     roles_path = deployment/roles/
 
 Create a ``requirements.yml`` file in your project's deployment
-directory.  It is recommended to include `tequila-common 
+directory.  It is recommended to include `tequila-common
 <https://github.com/caktus/tequila-common>`_, which sets up
-the project directory structure and users, and also `geerlingguy/nodejs 
+the project directory structure and users, and also `geerlingguy/nodejs
 <https://github.com/geerlingguy/ansible-role-nodejs>`_
 to install nodejs and any front-end packages that your project
 requires ::
@@ -59,7 +59,7 @@ requires ::
       version: v0.8.0
 
     - src: https://github.com/caktus/tequila-django
-      version: v0.9.3
+      version: v0.9.11
 
 Run ``ansible-galaxy`` with your requirements file ::
 
@@ -153,7 +153,7 @@ error if found.  This behavior can be disabled by setting
 Optimizations
 -------------
 
-You can turn on `SSH pipelining (http://docs.ansible.com/ansible/latest/intro_configuration.html#pipelining) 
+You can turn on `SSH pipelining (http://docs.ansible.com/ansible/latest/intro_configuration.html#pipelining)
 <http://docs.ansible.com/ansible/latest/intro_configuration.html#pipelining>`_
 to speed up ansible commands (by minimizing SSH operations). Add the following
 to your project's `ansible.cfg` file ::

--- a/templates/envfile.j2
+++ b/templates/envfile.j2
@@ -14,8 +14,10 @@ ADDITIONAL_DOMAINS="{{ additional_domains|default([])|join(',') }}"
 {% if cache_host is defined %}CACHE_HOST='{{ cache_host }}'
 {% endif %}
 {% if broker_host is defined %}BROKER_HOST='{{ broker_host }}'
+CELERY_BROKER_HOST='{{ broker_host }}'
 {% endif %}
 {% if broker_password is defined %}BROKER_PASSWORD='{{ broker_password }}'
+CELERY_BROKER_PASSWORD='{{ broker_password }}'
 {% endif %}
 {% if solr_host is defined %}SOLR_HOST='{{ solr_host }}'
 {% endif %}


### PR DESCRIPTION
From the Celery 4 release notes:

> [Celery 4] radically changes the configuration setting names, to be more consistent.
> 
> The changes are fully backwards compatible, so you have the option to wait until the old setting names are deprecated …

… but on SFA we have not taken that option. Onwards!!

The change that affects is us this:

> This will also add a prefix to settings that didn’t previously have one, for example `BROKER_URL` should be written `CELERY_BROKER_URL` …

The only two changes that we need to make (AFAICT) are to `BROKER_PASSWORD` and `BROKER_HOST`, creating second copies with the `CELERY_` prefix.