### PR TITLE
[TEQ-59] Add support for Celery events monitoring with camera

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,19 @@ Tequila-django
 
 Changes
 
+v 0.9.n on Month Day, Year
+--------------------------
+
+* Add additional variables to enable Celery event monitoring
+  with snapshots.
+
+  Per the remarks added to the "Variables" section of the
+  README, tequila-django now includes variables that allow
+  the user to turn on Celery event monitoring alongside
+  other Celery commands. This relies on the ``celery events``
+  command introduced in Celery 3.1, and by default it uses
+  the ``django-celery-monitor`` app to capture worker events.
+
 v 0.9.11 on March 19, 2018
 --------------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Tequila-django
 
 Changes
 
-v 0.9.n on Month Day, Year
+v 0.9.13 on June 1, 2018
 --------------------------
 
 * Add additional variables to enable Celery event monitoring

--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,20 @@ for the presence of any packages in this variable and will throw an
 error if found.  This behavior can be disabled by setting
 ``ignore_devdependencies`` to ``true``.
 
+The ``celery_events`` and ``celery_camera_class`` variables are used
+to enable and configure Celery event monitoring using the "snapshots"
+system, which allows worker activity to be tracked in a less expensive
+way than storing all event history on disk. Setting ``celery_events``
+to ``true`` will set up the ``celery events`` command to be run alongside
+the other Celery commands. By default this will use the
+`django-celery-monitor <https://github.com/jezdez/django-celery-monitor>`_
+app as its snapshot "camera", so either ensure that this app is installed
+in your project or change ``celery_camera_class`` to a string naming
+the alternative camera class to use (e.g. ``myapp.Camera``). For
+more on Celery event monitoring, see
+`the docs <http://docs.celeryproject.org/en/latest/userguide/monitoring.html>`_.
+
+
 
 Optimizations
 -------------

--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,8 @@ The following variables are used by the ``tequila-django`` role:
 - ``broker_host`` **optional**
 - ``broker_password`` **optional**
 - ``celery_worker_extra_args`` **default:** ``"--loglevel=INFO"``
+- ``celery_events`` **default:** ``false``
+- ``celery_camera_class`` **default:** ``"django_celery_monitor.camera.Camera"``
 - ``static_dir`` **default:** ``"{{ root_dir }}/public/static"``
 - ``media_dir`` **default:** ``"{{ root_dir }}/public/media"``
 - ``log_dir`` **default:** ``"{{ root_dir }}/log"``

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,5 @@ is_web: false
 is_worker: false
 ignore_devdependencies: false
 extra_env: {}
+celery_events: false
+celery_camera_class: "django_celery_monitor.camera.Camera"

--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -16,9 +16,10 @@
             group=root
             mode=0600
   when: celery_events
-  with_items:
-    - { name: "events", command: "events", flags: "--camera {{ celery_camera_class }} --pidfile /var/run/celery/celery-events.pid --loglevel=INFO " }
-
+  vars:
+    name: "events"
+    command: "events"
+    flags: "--camera {{ celery_camera_class }} --pidfile /var/run/celery/celery-events.pid --loglevel=INFO"
 
 # Celery PIDs are stored in a directory in /var/run/celery (a tmpfs mount) so
 # that no stale celery PID files can exist across reboots.

--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -6,11 +6,22 @@
             group=root
             mode=0600
   with_items:
-    - { name: "default", command: "worker", flags: "{{ celery_worker_extra_args|default('--loglevel=INFO') }}" }
+    - { name: "default", command: "worker", flags: "{{ celery_worker_extra_args|default('--loglevel=INFO') }}{% if celery_events %} --events{% endif %}" }
     - { name: "beat", command: "beat", flags: "--schedule={{ root_dir }}/celerybeat-schedule.db --pidfile=/var/run/celery/celerybeat.pid --loglevel=INFO" }
 
+- name: configure celery events
+  template: src=celery.conf
+            dest=/etc/supervisor/conf.d/{{ project_name }}-celery-events.conf
+            owner=root
+            group=root
+            mode=0600
+  when: celery_events
+  with_items:
+    - { name: "events", command: "events", flags: "--camera {{ celery_camera_class }} --pidfile /var/run/celery/celery-events.pid --loglevel=INFO " }
+
+
 # Celery PIDs are stored in a directory in /var/run/celery (a tmpfs mount) so
-# that no stale celery PID files can exist across reboots. 
+# that no stale celery PID files can exist across reboots.
 #
 # A systemd-tmpfiles setting is set up here so that /var/run/celery is created at
 # boot time with permissions allowing the project_name user to store their PIDs
@@ -38,4 +49,3 @@
   with_items:
     - default
     - beat
-

--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -17,9 +17,10 @@
             mode=0600
   when: celery_events
   vars:
-    name: "events"
-    command: "events"
-    flags: "--camera {{ celery_camera_class }} --pidfile /var/run/celery/celery-events.pid --loglevel=INFO"
+    item:
+      name: "events"
+      command: "events"
+      flags: "--camera {{ celery_camera_class }} --pidfile /var/run/celery/celery-events.pid --loglevel=INFO"
 
 # Celery PIDs are stored in a directory in /var/run/celery (a tmpfs mount) so
 # that no stale celery PID files can exist across reboots.

--- a/tasks/celery.yml
+++ b/tasks/celery.yml
@@ -1,13 +1,25 @@
 ---
-- name: configure celery and celery beat
+- name: configure celery
   template: src=celery.conf
-            dest=/etc/supervisor/conf.d/{{ project_name }}-celery-{{ item.name }}.conf
+            dest=/etc/supervisor/conf.d/{{ project_name }}-celery-{{ name }}.conf
             owner=root
             group=root
             mode=0600
-  with_items:
-    - { name: "default", command: "worker", flags: "{{ celery_worker_extra_args|default('--loglevel=INFO') }}{% if celery_events %} --events{% endif %}" }
-    - { name: "beat", command: "beat", flags: "--schedule={{ root_dir }}/celerybeat-schedule.db --pidfile=/var/run/celery/celerybeat.pid --loglevel=INFO" }
+  vars:
+    name: "default"
+    command: "worker"
+    flags: "{{ celery_worker_extra_args|default('--loglevel=INFO') }}{% if celery_events %} --events{% endif %}"
+
+- name: configure celery beat
+  template: src=celery.conf
+            dest=/etc/supervisor/conf.d/{{ project_name }}-celery-{{ name }}.conf
+            owner=root
+            group=root
+            mode=0600
+  vars:
+    name: "beat"
+    command: "beat"
+    flags: "--schedule={{ root_dir }}/celerybeat-schedule.db --pidfile=/var/run/celery/celerybeat.pid --loglevel=INFO"
 
 - name: configure celery events
   template: src=celery.conf
@@ -17,10 +29,9 @@
             mode=0600
   when: celery_events
   vars:
-    item:
-      name: "events"
-      command: "events"
-      flags: "--camera {{ celery_camera_class }} --pidfile /var/run/celery/celery-events.pid --loglevel=INFO"
+    name: "events"
+    command: "events"
+    flags: "--camera {{ celery_camera_class }} --pidfile /var/run/celery/celery-events.pid --loglevel=INFO"
 
 # Celery PIDs are stored in a directory in /var/run/celery (a tmpfs mount) so
 # that no stale celery PID files can exist across reboots.

--- a/templates/celery.conf
+++ b/templates/celery.conf
@@ -1,5 +1,5 @@
-[program:{{ project_name }}-celery-{{ item.name }}]
-command={{ source_dir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/celery -A {{ project_name }} {{ item.command }} {{ item.flags }}
+[program:{{ project_name }}-celery-{{ name }}]
+command={{ source_dir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/celery -A {{ project_name }} {{ command }} {{ flags }}
 user={{ project_name }}
 directory={{ source_dir }}
 autostart=true


### PR DESCRIPTION
See [this page of the Celery docs](http://docs.celeryproject.org/en/latest/userguide/monitoring.html#events) to understand exactly what's going on here.

In short, this adds support for adding a `celery_events: true` value to your project deploy settings to get the supervisor to run `celery events` to dump event information into a specified "camera" (given by `celery_camera_class`, by default the `django-celery-monitor` camera) and to get the `celery worker` command to use the `--events` flag.