### PR TITLE
Remove the checks for non-trivial entries in devDependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,8 +3,18 @@ Tequila-django
 
 Changes
 
-v 0.9.11 on March 19, 2018
---------------------------
+v 0.9.12 on Apr 19, 2018
+------------------------
+
+* Remove the check-and-fail for entries in the packages.json
+  ``devDependencies`` block.  This was just protecting against a
+  corner of npm, no other portion of the deployment depends on it, and
+  it will cause deployments to new environments to fail since npm
+  hasn't been installed yet.
+
+
+v 0.9.11 on Mar 19, 2018
+------------------------
 
 * Add additional env vars to account for Celery 4's renamed
   configuration settings.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -136,16 +136,6 @@
   register: build_script
   when: package_json.stat.exists == True
 
-- name: check developer dependencies
-  command: npm ls -dev --parseable --prefix {{ source_dir }}
-  register: dev_dependencies
-  when: package_json.stat.exists == True
-
-- name: fail when there are project-level devDependencies
-  fail:
-    msg: "There are packages listed under `devDependencies`. Please move them to `dependencies` instead."
-  when: not ignore_devdependencies and package_json.stat.exists == True and dev_dependencies.stdout_lines|length > 1
-
 - name: clear out leftover build cruft from the project requirements
   file: path={{ venv_dir }}/build state=absent
 


### PR DESCRIPTION
no other part of the deploy process depends on it, it was just
guarding against a weird corner of npm, and this task causes the
deploy to fail on new environments.

TEQ-62