### PR TITLE
Support django project in subdir, and a few other things

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Tequila-django
 
 Changes
 
-v X.Y.Z on MMM dd, YYYY
+v 0.9.16 on Aug 6, 2018
 -----------------------
 
 * New variable ``project_subdir`` to accomodate projects where

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ v X.Y.Z on MMM dd, YYYY
 * New variable ``project_subdir`` to accomodate projects where
   the Django project (``manage.py`` etc.) are in a subdirectory of
   the repository.
+* New variable ``wsgi_module`` to accomodate projects where the
+  package of the wsgi module is not ``{{ project_name }}.wsgi``.
 
 v 0.9.15 on July 31, 2018
 --------------------------

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,12 @@ The following variables are used by the ``tequila-django`` role:
 - ``github_deploy_key`` **required if source_is_local is false**
 - ``local_project_dir`` **required if source_is_local**
 - ``extra_env`` **default:** empty dict
+- ``project_subdir`` **default:** ``.`` - if a project's main source
+  directory is a subdir of the git repo checkout top directory, e.g.
+  manage.py is not in the top directory and you have to cd to a subdirectory
+  before running it, then set this to the relative path of that subdirectory.
+- ``wsgi_module`` **default:** ``{{ project_name }}.wsgi`` - allow
+  configuring an alternate path to the project's wsgi module.
 
 The ``extra_env`` variable is a dict of keys and values that is
 desired to be injected into the environment as variables, via the

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ The following variables are used by the ``tequila-django`` role:
 - ``github_deploy_key`` **required if source_is_local is false**
 - ``local_project_dir`` **required if source_is_local**
 - ``extra_env`` **default:** empty dict
-- ``project_subdir`` **default:** ``.`` - if a project's main source
+- ``project_subdir`` **default:** ``""`` - if a project's main source
   directory is a subdir of the git repo checkout top directory, e.g.
   manage.py is not in the top directory and you have to cd to a subdirectory
   before running it, then set this to the relative path of that subdirectory.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,5 @@ is_worker: false
 extra_env: {}
 celery_events: false
 celery_camera_class: "django_celery_monitor.camera.Camera"
+project_subdir: .
+wsgi_module: "{{ project_name }}.wsgi"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@ python_version: "2.7"
 root_dir: "/var/www/{{ project_name }}"
 source_dir: "{{ root_dir }}/src"
 venv_dir: "{{ root_dir }}/env"
-ssh_dir: "/home/{{ project_name }}/.ssh"
+ssh_dir: "/home/{{ project_user }}/.ssh"
 requirements_file: "{{ source_dir }}/requirements/{{ env_name }}.txt"
 project_user: "{{ project_name }}"
 project_settings: "{{ project_name }}.settings.deploy"
@@ -22,5 +22,6 @@ is_worker: false
 extra_env: {}
 celery_events: false
 celery_camera_class: "django_celery_monitor.camera.Camera"
-project_subdir: .
+project_subdir: ""
+django_dir: "{{ source_dir ~ '/' ~ project_subdir if project_subdir != '' else source_dir }}"
 wsgi_module: "{{ project_name }}.wsgi"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,13 @@
 ---
+# Use manage.sh so we use the same env vars from .env that we use on
+# other invocations of django manage.py. Unfortunately that means we cannot
+# use the ansible django_manage module.
+# TODO: see if we could use an ansible lookup plugin to read the .env file
+# and pass the values to the environment configuration item?
 - name: collectstatic
-  django_manage:
-    command: collectstatic
-    app_path: "{{ source_dir }}"
-    virtualenv: "{{ venv_dir }}"
+  shell: "{{ root_dir }}/manage.sh collectstatic --noinput"
+  args:
+    chdir: "{{ source_dir }}/{{ project_subdir }}"
   become_user: "{{ project_user }}"
   vars:
     ansible_ssh_pipelining: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,7 +7,7 @@
 - name: collectstatic
   shell: "{{ root_dir }}/manage.sh collectstatic --noinput"
   args:
-    chdir: "{{ source_dir }}/{{ project_subdir }}"
+    chdir: "{{ django_dir }}"
   become_user: "{{ project_user }}"
   vars:
     ansible_ssh_pipelining: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -150,7 +150,7 @@
   when: use_newrelic
 
 - name: set up the project python path
-  copy: content="{{ source_dir }}/{{ project_subdir }}"
+  copy: content="{{ django_dir }}"
         dest={{ venv_dir }}/lib/python{{ python_version }}/site-packages/project.pth
         owner={{ project_user }}
         group={{ project_user }}
@@ -158,26 +158,30 @@
 # THIS needs to come AFTER syncing the source to the server,
 # since that might remove files like .env that weren't in the
 # source directory locally.
+# .env should be in the Django dir in case the Django program
+# looks for it in its own top directory.
 - name: create/update .env file
   template: >
-    dest={{ source_dir }}/{{ project_subdir }}/.env
+    dest={{ django_dir }}/.env
     owner={{ project_user }}
     group={{ project_user }}
     mode=400
     src=envfile.j2
 
+# dotenv.sh is in the Django dir since that's where .env is.
 - name: add the dotenv.sh helper script
   copy: src=dotenv.sh
-        dest={{ source_dir }}/{{ project_subdir }}/dotenv.sh
+        dest={{ django_dir }}/dotenv.sh
         owner={{ project_user }}
         group={{ project_user }}
         mode=700
 
+# manage.sh is at the very top level, I guess for convenience?
 - name: copy shell script wrapper for manage.py
   template: src=manage.sh
             dest={{ root_dir }}/manage.sh
-            owner={{ project_name }}
-            group={{ project_name }}
+            owner={{ project_user }}
+            group={{ project_user }}
             mode=700
 
 # We're not using django_manage at the moment in tequila, but the cost of
@@ -185,7 +189,7 @@
 # django_manage again:
 - name: make manage.py executable (because django_manage expects it)
   file: >
-    path={{ source_dir }}/manage.py
+    path={{ django_dir }}/manage.py
     mode=0755
   become_user: "{{ project_user }}"
   vars:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -150,7 +150,7 @@
   when: use_newrelic
 
 - name: set up the project python path
-  copy: content="{{ source_dir }}"
+  copy: content="{{ source_dir }}/{{ project_subdir }}"
         dest={{ venv_dir }}/lib/python{{ python_version }}/site-packages/project.pth
         owner={{ project_user }}
         group={{ project_user }}
@@ -160,7 +160,7 @@
 # source directory locally.
 - name: create/update .env file
   template: >
-    dest={{ source_dir }}/.env
+    dest={{ source_dir }}/{{ project_subdir }}/.env
     owner={{ project_user }}
     group={{ project_user }}
     mode=400
@@ -168,11 +168,21 @@
 
 - name: add the dotenv.sh helper script
   copy: src=dotenv.sh
-        dest={{ source_dir }}/dotenv.sh
+        dest={{ source_dir }}/{{ project_subdir }}/dotenv.sh
         owner={{ project_user }}
         group={{ project_user }}
         mode=700
 
+- name: copy shell script wrapper for manage.py
+  template: src=manage.sh
+            dest={{ root_dir }}/manage.sh
+            owner={{ project_name }}
+            group={{ project_name }}
+            mode=700
+
+# We're not using django_manage at the moment in tequila, but the cost of
+# keeping this is trivial, and it'll avoid mysterious errors if we start using
+# django_manage again:
 - name: make manage.py executable (because django_manage expects it)
   file: >
     path={{ source_dir }}/manage.py

--- a/tasks/web.yml
+++ b/tasks/web.yml
@@ -22,11 +22,16 @@
 
 # TODO: let connections to 8000 through the firewall if we are load-balancing.
 
+
+# Use manage.sh so we use the same env vars from .env that we use on
+# other invocations of django manage.py. Unfortunately that means we cannot
+# use the ansible django_manage module.
+# TODO: see if we could use an ansible lookup plugin to read the .env file
+# and pass the values to the environment configuration item?
 - name: migrate
-  django_manage:
-    command: migrate --noinput -v 0
-    app_path: "{{ source_dir }}"
-    virtualenv: "{{ venv_dir }}"
+  shell: "{{ root_dir }}/manage.sh migrate --noinput -v 0"
+  args:
+    chdir: "{{ source_dir }}/{{ project_subdir }}"
   become_user: "{{ project_user }}"
   run_once: true
   vars:
@@ -34,13 +39,9 @@
 
 - name: restart gunicorn
   supervisorctl: name={{ project_name }}-server state=restarted
-
-- name: copy shell script wrapper for manage.py
-  template: src=manage.sh
-            dest={{ root_dir }}/manage.sh
-            owner={{ project_name }}
-            group={{ project_name }}
-            mode=700
+  # supervisorctl is idiotic. If your program isn't running, telling
+  # supervisotctl to restart it is an error. Why not just start it?
+  ignore_errors: true
 
 # Note: we want the collectstatic step to happen at the very end of
 # the roles section for the current playbook, so that it'll still

--- a/tasks/web.yml
+++ b/tasks/web.yml
@@ -39,7 +39,7 @@
 
 - name: restart gunicorn
   supervisorctl: name={{ project_name }}-server state=restarted
-  # If your program isn't running, telling supervisotctl to restart
+  # If your program isn't running, telling supervisorctl to restart
   # it is an error. I would think that the Ansible module would
   # handle that, since they're supposed to be idempotent.
   # For now, just ignore errors:

--- a/tasks/web.yml
+++ b/tasks/web.yml
@@ -31,7 +31,7 @@
 - name: migrate
   shell: "{{ root_dir }}/manage.sh migrate --noinput -v 0"
   args:
-    chdir: "{{ source_dir }}/{{ project_subdir }}"
+    chdir: "{{ django_dir }}"
   become_user: "{{ project_user }}"
   run_once: true
   vars:
@@ -39,8 +39,10 @@
 
 - name: restart gunicorn
   supervisorctl: name={{ project_name }}-server state=restarted
-  # supervisorctl is idiotic. If your program isn't running, telling
-  # supervisotctl to restart it is an error. Why not just start it?
+  # If your program isn't running, telling supervisotctl to restart
+  # it is an error. I would think that the Ansible module would
+  # handle that, since they're supposed to be idempotent.
+  # For now, just ignore errors:
   ignore_errors: true
 
 # Note: we want the collectstatic step to happen at the very end of

--- a/templates/celery.conf
+++ b/templates/celery.conf
@@ -1,7 +1,7 @@
 [program:{{ project_name }}-celery-{{ name }}]
-command={{ source_dir }}/{{ project_subdir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/celery -A {{ project_name }} {{ command }} {{ flags }}
+command={{ django_dir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/celery -A {{ project_name }} {{ command }} {{ flags }}
 user={{ project_user }}
-directory={{ source_dir }}/{{ project_subdir }}
+directory={{ django_dir }}
 autostart=true
 autorestart=true
 stopasgroup=false

--- a/templates/celery.conf
+++ b/templates/celery.conf
@@ -1,7 +1,7 @@
 [program:{{ project_name }}-celery-{{ name }}]
-command={{ source_dir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/celery -A {{ project_name }} {{ command }} {{ flags }}
-user={{ project_name }}
-directory={{ source_dir }}
+command={{ source_dir }}/{{ project_subdir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/celery -A {{ project_name }} {{ command }} {{ flags }}
+user={{ project_user }}
+directory={{ source_dir }}/{{ project_subdir }}
 autostart=true
 autorestart=true
 stopasgroup=false

--- a/templates/celery_tmpfile.conf
+++ b/templates/celery_tmpfile.conf
@@ -1,1 +1,1 @@
-D /var/run/celery 0700 {{ project_name }} {{ project_name }}
+D /var/run/celery 0700 {{ project_user }} {{ project_name }}

--- a/templates/envfile.j2
+++ b/templates/envfile.j2
@@ -1,7 +1,8 @@
 {# template for .env file #}
 ENVIRONMENT='{{ env_name }}'
 PYTHONUNBUFFERED=1
-PATH=/usr/local/bin:$PATH
+{# the geerlingguy.nodejs role's npm installs global programs in /usr/local/lib/npm/bin #}
+PATH=/usr/local/bin:/usr/local/lib/npm/bin:$PATH
 DJANGO_SETTINGS_MODULE='{{ project_settings }}'
 SECRET_KEY='{{ secret_key }}'
 DB_NAME='{{ db_name }}'

--- a/templates/gunicorn.conf
+++ b/templates/gunicorn.conf
@@ -1,5 +1,9 @@
 [program:{{ project_name }}-server]
 command={{ django_dir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/gunicorn {{ wsgi_module }}:application --log-syslog --bind=0.0.0.0:{{ project_port }} --workers={{ gunicorn_num_workers }} {% if gunicorn_num_threads is defined %}--threads={{ gunicorn_num_threads }}{% endif %}
+
+; The blank line before this is required. Do not remove it please.
+; Otherwise the command= and user= lines get joined into one.
+; (Maybe due to the previous line ending with Jinja2 ``endif``?)
 user={{ project_user }}
 directory={{ django_dir }}
 autostart=true

--- a/templates/gunicorn.conf
+++ b/templates/gunicorn.conf
@@ -1,8 +1,8 @@
 [program:{{ project_name }}-server]
-command={{ source_dir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/gunicorn {{ project_name }}.wsgi:application --bind=0.0.0.0:8000 --workers={{ gunicorn_num_workers }} {% if gunicorn_num_threads is defined %}--threads={{ gunicorn_num_threads }}{% endif %}
+command={{ source_dir }}/{{ project_subdir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/gunicorn {{ wsgi_module }}:application --log-syslog --bind=0.0.0.0:{{ project_port }} --workers={{ gunicorn_num_workers }} {% if gunicorn_num_threads is defined %}--threads={{ gunicorn_num_threads }}{% endif %}
 
 user={{ project_user }}
-directory={{ source_dir }}
+directory={{ source_dir }}/{{ project_subdir }}
 autostart=true
 autorestart=true
 stopasgroup=false

--- a/templates/gunicorn.conf
+++ b/templates/gunicorn.conf
@@ -1,8 +1,8 @@
 [program:{{ project_name }}-server]
-command={{ source_dir }}/{{ project_subdir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/gunicorn {{ wsgi_module }}:application --log-syslog --bind=0.0.0.0:{{ project_port }} --workers={{ gunicorn_num_workers }} {% if gunicorn_num_threads is defined %}--threads={{ gunicorn_num_threads }}{% endif %}
+command={{ django_dir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/gunicorn {{ wsgi_module }}:application --log-syslog --bind=0.0.0.0:{{ project_port }} --workers={{ gunicorn_num_workers }} {% if gunicorn_num_threads is defined %}--threads={{ gunicorn_num_threads }}{% endif %}
 
 user={{ project_user }}
-directory={{ source_dir }}/{{ project_subdir }}
+directory={{ django_dir }}
 autostart=true
 autorestart=true
 stopasgroup=false

--- a/templates/manage.sh
+++ b/templates/manage.sh
@@ -1,3 +1,3 @@
 # Shell script to run a management command
-cd {{ source_dir }}
-{{ venv_dir }}/bin/python {{ source_dir }}/manage.py $@
+cd {{ source_dir }}/{{ project_subdir }}
+./dotenv.sh {{ venv_dir }}/bin/python {{ source_dir }}/{{ project_subdir }}/manage.py $@

--- a/templates/manage.sh
+++ b/templates/manage.sh
@@ -1,3 +1,3 @@
 # Shell script to run a management command
-cd {{ source_dir }}/{{ project_subdir }}
-./dotenv.sh {{ venv_dir }}/bin/python {{ source_dir }}/{{ project_subdir }}/manage.py $@
+cd {{ django_dir }}
+./dotenv.sh {{ venv_dir }}/bin/python {{ django_dir }}/manage.py $@


### PR DESCRIPTION
* Allow tequila to work with a django repository where the manage.py,
  app dirs, etc are all in a subdir of the top directory of the
  repository.
* Allow configuring the package path to the Django project's wsgi
  module.
* A few changes so everywhere we run Django, we use the environment
  settings from the .env file that Tequila creates.
* Add the directory to the path where the npm from geerlingguy.nodejs
  installs global programs.