### PR TITLE
[TEQ-71] Use manage.sh and dotenv when running Django commands

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,9 +1,6 @@
 ---
 - name: collectstatic
-  django_manage:
-    command: collectstatic
-    app_path: "{{ source_dir }}"
-    virtualenv: "{{ venv_dir }}"
+  shell: "{{ root_dir }}/manage.sh collectstatic --noinput -v 0"
   become_user: "{{ project_user }}"
   vars:
     ansible_ssh_pipelining: true

--- a/tasks/web.yml
+++ b/tasks/web.yml
@@ -22,11 +22,20 @@
 
 # TODO: let connections to the {{ project_port }} through the firewall if we are load-balancing.
 
+- name: copy shell script wrapper for manage.py
+  template: src=manage.sh
+            dest={{ root_dir }}/manage.sh
+            owner={{ project_user }}
+            group={{ project_user }}
+            mode=700
+
+# Use manage.sh so we use the same env vars from .env that we use on
+# other invocations of django manage.py. Unfortunately that means we cannot
+# use the ansible django_manage module.
+# TODO: see if we could use an ansible lookup plugin to read the .env file
+# and pass the values to the environment configuration item?
 - name: migrate
-  django_manage:
-    command: migrate --noinput -v 0
-    app_path: "{{ source_dir }}"
-    virtualenv: "{{ venv_dir }}"
+  shell: "{{ root_dir }}/manage.sh migrate --noinput -v 0"
   become_user: "{{ project_user }}"
   run_once: true
   vars:
@@ -34,13 +43,6 @@
 
 - name: restart gunicorn
   supervisorctl: name={{ project_name }}-server state=restarted
-
-- name: copy shell script wrapper for manage.py
-  template: src=manage.sh
-            dest={{ root_dir }}/manage.sh
-            owner={{ project_user }}
-            group={{ project_user }}
-            mode=700
 
 # Note: we want the collectstatic step to happen at the very end of
 # the roles section for the current playbook, so that it'll still

--- a/templates/manage.sh
+++ b/templates/manage.sh
@@ -1,3 +1,3 @@
 # Shell script to run a management command
 cd {{ source_dir }}
-{{ venv_dir }}/bin/python {{ source_dir }}/manage.py $@
+./dotenv.sh {{ venv_dir }}/bin/python {{ source_dir }}/manage.py $@


### PR DESCRIPTION
tequila-django runs collectstatic and migrate without specifying any particular settings to use. Some projects probably don't care because they've set the default settings in manage.py to their deployed settings, or something close enough to them. But not all projects do that.

It's not just settings. Many important pieces of data are passed to Django via environment variables, and unless your Django project specifically adds code to look for and properly process a .env file, your Django instance won't get the information it needs, like the location and credentials for its database.

The safest approach seems to be to always use manage.sh or. dotenv when running Django commands.