### PR TITLE
Allow customization of the celery application name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ v 0.9.n+1 on Month Day, Year
 * TBD
 
 
+v 0.9.19 on Nov 21, 2018
+----------------------------
+
+* Add ability to customize Celery app name via ``celery_app`` variable.
+
+
 v 0.9.18 on Sep 26, 2018
 ----------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,7 @@ The following variables are used by the ``tequila-django`` role:
 - ``cache_host`` **optional**
 - ``broker_host`` **optional**
 - ``broker_password`` **optional**
+- ``celery_app`` **default:** ``"{{ project_name }}"`` (e.g. the app name passed to ``celery -A APP_NAME worker``)
 - ``celery_worker_extra_args`` **default:** ``"--loglevel=INFO"``
 - ``celery_events`` **default:** ``false``
 - ``celery_camera_class`` **default:** ``"django_celery_monitor.camera.Camera"``

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,7 @@ is_web: false
 is_worker: false
 is_celery_beat: false
 extra_env: {}
+celery_app: "{{ project_name }}"
 celery_events: false
 celery_camera_class: "django_celery_monitor.camera.Camera"
 project_subdir: ""

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,7 +69,7 @@
 
 - name: restart supervisord
   service: name=supervisor state=restarted
-  when: supervisord_conf|changed
+  when: supervisord_conf is changed
 
 - name: store path to github key
   set_fact:

--- a/templates/celery.conf
+++ b/templates/celery.conf
@@ -1,5 +1,5 @@
 [program:{{ project_name }}-celery-{{ name }}]
-command={{ django_dir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/celery -A {{ project_name }} {{ command }} {{ flags }}
+command={{ django_dir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/celery -A {{ celery_app }} {{ command }} {{ flags }}
 user={{ project_user }}
 directory={{ django_dir }}
 autostart=true


### PR DESCRIPTION
Allow projects to specify a celery app name, a Python module, if the default ``{{ project_name }}`` doesn't work.