### PR TITLE
Don't follow symlinks

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -120,6 +120,7 @@
     group: "{{ project_user }}"
     path: "{{ source_dir }}"
     recurse: yes
+    follow: false
 
 - name: delete pyc files
   shell: find {{ source_dir }} -name '*.pyc' -delete


### PR DESCRIPTION
When changing ownership of the source code, don't
follow symlinks. If code was copied from a local
dev environment, it might have symlinks that end
up resulting in an infinite loop trying to recurse
and following them.