### PR TITLE
Remove --log-syslog from the supervisor gunicorn command  line

### DIFF
--- a/templates/gunicorn.conf
+++ b/templates/gunicorn.conf
@@ -1,5 +1,5 @@
 [program:{{ project_name }}-server]
-command={{ django_dir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/gunicorn {{ wsgi_module }}:application --log-syslog --bind=0.0.0.0:{{ project_port }} --workers={{ gunicorn_num_workers }} {% if gunicorn_num_threads is defined %}--threads={{ gunicorn_num_threads }}{% endif %}
+command={{ django_dir }}/dotenv.sh {% if use_newrelic %}{{ venv_dir }}/bin/newrelic-admin run-program {% endif %}{{ venv_dir }}/bin/gunicorn {{ wsgi_module }}:application --bind=0.0.0.0:{{ project_port }} --workers={{ gunicorn_num_workers }} {% if gunicorn_num_threads is defined %}--threads={{ gunicorn_num_threads }}{% endif %}
 
 ; The blank line before this is required. Do not remove it please.
 ; Otherwise the command= and user= lines get joined into one.


### PR DESCRIPTION
Supervisor is already redirecting stdout to syslog with the stdout_logfile=syslog line.
Writing to syslog twice causes an "OSError: [Errno 9] Bad file descriptor" error and a large stack trace in syslog for every 200 response.