### PR TITLE
Improvements to how we use rsync for source

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,8 +6,9 @@ Changes
 v 0.9.n+1 on Month Day, Year
 ----------------------------
 
-* TBD
-
+* When rsyncing local source to server (when source_is_local is true,
+  mainly when using vagrant), exclude deployment dir, and use the
+  same ssh as ansible.
 
 v 0.9.20 on Dec 27, 2018
 ------------------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -99,6 +99,9 @@
 
 # NB! The trailing '/' on the 'src' parameter is significant, do not remove!
 # (see the docs: http://docs.ansible.com/ansible/synchronize_module.html)
+# Exclude 'deployment' dir since we don't need it on the server and it seems
+# to be prone to circular symlinks that break rsync.
+# Use whatever ssh executable ansible is using.
 - name: sync source from local directory
   synchronize:
     dest: "{{ source_dir }}"
@@ -106,11 +109,14 @@
     delete: yes
     rsync_path: "sudo rsync"  # Use sudo on the remote system
     recursive: true
+    set_remote_user: no
     rsync_opts:
       - "--exclude=.env"
       - "--exclude=.git"
       - "--exclude=node_modules"
+      - "--exclude=deployment"
       - "--exclude=*.pyc"
+      - "--rsh={{ ansible_ssh_executable }}"
   become: no  # stops synchronize trying to sudo locally
   when: source_is_local
 


### PR DESCRIPTION
When rsyncing local source to server (when source_is_local is true,
mainly when using vagrant), exclude deployment dir, and use the
same ssh as ansible.