### PR TITLE
Add option to pin new relic version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Tequila-django
 
 Changes
 
-v 0.9.22 on Apr 1, 2019
+v 0.9.22 on Apr 5, 2019
 ------------------------
 
 * Allow pinning to a specific version of New Relic with ``new_relic_version``

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Tequila-django
 
 Changes
 
+v 0.9.22 on Apr 1, 2019
+------------------------
+
+* Allow pinning to a specific version of New Relic with ``new_relic_version``
+
+
 v 0.9.21 on Jan 28, 2019
 ------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,8 @@ The following variables are used by the ``tequila-django`` role:
 - ``requirements_extra_args`` **default:** ``""``
 - ``use_newrelic`` **default:** ``false``
 - ``new_relic_license_key`` **required if use_newrelic is true**
+- ``new_relic_version`` **default:** ``""`` pin to a specific version of
+  `New Relic APM <https://pypi.org/project/newrelic/>`_, e.g. ``"4.14.0.115"``
 - ``cloud_staticfiles`` **default:** ``false``
 - ``gunicorn_version`` **optional**
 - ``gunicorn_num_workers`` **required**

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ static_dir: "{{ root_dir }}/public/static"
 media_dir: "{{ root_dir }}/public/media"
 log_dir: "{{ root_dir }}/log"
 use_newrelic: false
-newrelic_version: ""
+new_relic_version: ""
 source_is_local: false
 is_web: false
 is_worker: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,7 @@ static_dir: "{{ root_dir }}/public/static"
 media_dir: "{{ root_dir }}/public/media"
 log_dir: "{{ root_dir }}/log"
 use_newrelic: false
+newrelic_version: ""
 source_is_local: false
 is_web: false
 is_worker: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -180,7 +180,18 @@
   become_user: "{{ project_user }}"
   vars:
     ansible_ssh_pipelining: true
-  when: use_newrelic
+  when: use_newrelic and not new_relic_version|default(false)
+
+- name: optionally install newrelic at specific version
+  pip: name=newrelic
+       state=present
+       version={{ new_relic_version }}
+       virtualenv={{ venv_dir }}
+       virtualenv_python=/usr/bin/python{{ python_version }}
+  become_user: "{{ project_user }}"
+  vars:
+    ansible_ssh_pipelining: true
+  when: use_newrelic and new_relic_version|default(false)
 
 - name: set up the project python path
   copy: content="{{ django_dir }}"


### PR DESCRIPTION
Allow tequila users to pin to a specific version of New Relic.