### PR TITLE
Change file/directory permissions for supervisor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,7 +7,7 @@ v 0.9.26 on ???
 ------------------------
 * Omit ``version`` parameter to "optionally install newrelic" task when ``new_relic_version``
   is an empty string.
-
+* Change file permissions for supervisor, to allow group access.
 
 v 0.9.25 on Sep 24, 2019
 ------------------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,7 @@
     dest: /etc/init.d/supervisor
     owner: root
     group: root
-    mode: 0744
+    mode: 0755
 
 - name: create directory paths for supervisor
   file:
@@ -36,7 +36,7 @@
     state: directory
     owner: root
     group: root
-    mode: 0744
+    mode: 0755
   with_items:
     - /var/log/supervisor
     - /etc/supervisor/conf.d


### PR DESCRIPTION
This will change the filesystem permissions on 2 directories and 1 init script. It makes more sense for these to be 0755 rather than 0744 (and on one client project we have a separate task to change the log directories to be 0755 so that papertrail can read them)