### PR TITLE
Fix empty string newrelic_version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,12 @@ Tequila-django
 
 Changes
 
+v 0.9.26 on ???
+------------------------
+* Omit ``version`` parameter to "optionally install newrelic" task when ``new_relic_version``
+  is an empty string.
+
+
 v 0.9.25 on Sep 24, 2019
 ------------------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -187,7 +187,7 @@
   pip:
     name: newrelic
     state: "{{ new_relic_version|default(false)|ternary('present','latest') }}"
-    version: "{{ new_relic_version|default(omit) }}"
+    version: "{{ new_relic_version|default(omit,true) }}"
     virtualenv: "{{ venv_dir }}"
     virtualenv_python: "/usr/bin/python{{ python_version }}"
   become_user: "{{ project_user }}"


### PR DESCRIPTION
Omit ``version`` parameter to "optionally install newrelic" task when ``new_relic_version`` is an empty string.