### PR TITLE
Allow overriding the default supervisor version.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,10 @@ Tequila-django
 
 Changes
 
+v 0.9.27 on ???????????
+-----------------------
+* Allow overriding the default supervisor version.
+
 v 0.9.26 on Oct 2, 2019
 -----------------------
 * Omit ``version`` parameter to "optionally install newrelic" task when ``new_relic_version``

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,7 @@ The following variables are used by the ``tequila-django`` role:
 - ``new_relic_license_key`` **required if use_newrelic is true**
 - ``new_relic_version`` **default:** ``""`` pin to a specific version of
   `New Relic APM <https://pypi.org/project/newrelic/>`_, e.g. ``"4.14.0.115"``
+- ``supervisor_version`` **default:** ``"3.0"``
 - ``cloud_staticfiles`` **default:** ``false``
 - ``gunicorn_version`` **optional**
 - ``gunicorn_num_workers`` **required**

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,7 @@ media_dir: "{{ root_dir }}/public/media"
 log_dir: "{{ root_dir }}/log"
 use_newrelic: false
 new_relic_version: ""
+supervisor_version: "3.0"
 source_is_local: false
 is_web: false
 is_worker: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: pip install supervisor
   pip:
     name: supervisor
-    version: "3.0"
+    version: "{{ supervisor_version | default(omit, true) }}"
 
 - name: upload supervisor init script
   copy:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
 - name: pip install supervisor
   pip:
     name: supervisor
-    version: "{{ supervisor_version | default(omit, true) }}"
+    version: "{{ supervisor_version }}"
 
 - name: upload supervisor init script
   copy:

--- a/templates/celery.conf
+++ b/templates/celery.conf
@@ -10,9 +10,12 @@ startsecs=1
 ; Need to wait for currently executing tasks to finish at shutdown.
 ; Increase this if you have very long running tasks.
 stopwaitsecs=60
+{% if supervisor_version is version_compare('4.0', '<') %}
 # Supervisor 3.x:
 stdout_logfile=syslog
 redirect_stderr=true
+{% else %}
 # Supervisor 4.0:
-#stdout_syslog=true
-#stderr_syslog=true
+stdout_syslog=true
+stderr_syslog=true
+{% endif %}

--- a/templates/gunicorn.conf
+++ b/templates/gunicorn.conf
@@ -11,9 +11,12 @@ autorestart=true
 stopasgroup=false
 killasgroup=true
 stopwaitsecs=60
+{% if supervisor_version is version_compare('4.0', '<') %}
 # Supervisor 3.x:
 stdout_logfile=syslog
 redirect_stderr=true
+{% else %}
 # Supervisor 4.0:
-#stdout_syslog=true
-#stderr_syslog=true
+stdout_syslog=true
+stderr_syslog=true
+{% endif %}


### PR DESCRIPTION
Needed when using Python 3, where `supervisor>=4` is required. Without overriding, still defaults to `"3.0"` as before.