### PR TITLE
Force gunicorn version to specified along with other requirements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Tequila-django
 
 Changes
 
+v 0.9.28 on Feb 24, 2020
+------------------------
+* Remove support for ``gunicorn_version``. Instead, projects should pin the specific
+  gunicorn version that they want to use in their requirements.txt file.
+
 v 0.9.27 on Oct 17, 2019
 ------------------------
 * Allow overriding the default supervisor version.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2019, Caktus Consulting Group, LLC
+Copyright (c) 2016-2020, Caktus Consulting Group, LLC
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.rst
+++ b/README.rst
@@ -109,7 +109,6 @@ The following variables are used by the ``tequila-django`` role:
   `New Relic APM <https://pypi.org/project/newrelic/>`_, e.g. ``"4.14.0.115"``
 - ``supervisor_version`` **default:** ``"3.0"``
 - ``cloud_staticfiles`` **default:** ``false``
-- ``gunicorn_version`` **optional**
 - ``gunicorn_num_workers`` **required**
 - ``gunicorn_num_threads`` **optional** (note: gunicorn sets this at ``1`` if ``--threads=...`` is not given)
 - ``project_user`` **default:** ``"{{ project_name }}"``

--- a/tasks/web-gunicorn.yml
+++ b/tasks/web-gunicorn.yml
@@ -1,14 +1,19 @@
 ---
-- name: install gunicorn
-  pip:
-    name: gunicorn
-    state: present
-    version: "{{ gunicorn_version|default(omit) }}"
-    virtualenv: "{{ venv_dir }}"
-    virtualenv_python: /usr/bin/python{{ python_version }}
+- name: halt if gunicorn_version is set
+  assert:
+    that: gunicorn_version is not defined
+    fail_msg: "gunicorn_version is no longer supported. Remove it from your Ansible variables and instead pin `gunicorn==x.y` in your project's requirements"
+
+- name: ensure that gunicorn is present in the virtualenv
+  command: "{{ venv_dir }}/bin/pip show gunicorn"
   become_user: "{{ project_user }}"
-  vars:
-    ansible_ssh_pipelining: true
+  ignore_errors: True
+  register: result
+
+- name: warn if gunicorn is not installed
+  fail:
+    msg: please specify gunicorn in your project's requirements file
+  when: result is failed
 
 - name: configure gunicorn
   template:


### PR DESCRIPTION
If we allow `gunicorn_version` to be specified in Tequila/Ansible, then it isn't picked up by the tools that we use to scan our projects for pip vulnerabilities (like Github security alerts, requires.io, or pyup.io, etc)

This PR will cause a the deployment to halt if: 
1) it finds that `gunicorn_version` is set, or
2) it doesn't find the gunicorn package installed in the virtualenv

In both case, it will show a message instructing the user to put gunicorn in the project's requirements.